### PR TITLE
now it's possible to select vae

### DIFF
--- a/gligen_gui/static/js/extra.js
+++ b/gligen_gui/static/js/extra.js
@@ -109,6 +109,13 @@ const State = {
     return localStorage.checkpoint_name;
   },
 
+  set vae_name(val) {
+    localStorage.vae_name = val;
+  },
+  get vae_name() {
+    return localStorage.vae_name || "default";
+  },
+
   set sampler_name(val) {
     localStorage.sampler_name = val;
   },

--- a/gligen_gui/static/js/nodes.js
+++ b/gligen_gui/static/js/nodes.js
@@ -10,6 +10,18 @@ function nodeCheckpointLoaderSimple(name) {
   };
 }
 
+function nodeVAELoader(name) {
+  return {
+    inputs: {
+      vae_name: name,
+    },
+    class_type: "VAELoader",
+    _meta: {
+      title: "Load VAE",
+    }
+  }
+}
+
 function nodeKSampler(
   seed,
   steps,
@@ -67,11 +79,11 @@ function nodeCLIPTextEncode(prompt, model_in) {
   };
 }
 
-function nodeVAEDecode(model_in, samples_in) {
+function nodeVAEDecode(input_provider, provider_output_index, samples_in) {
   return {
     inputs: {
       samples: [String(samples_in), 0],
-      vae: [String(1), 2],
+      vae: [String(input_provider), provider_output_index],
     },
     class_type: "VAEDecode",
     _meta: {

--- a/gligen_gui/static/js/script.js
+++ b/gligen_gui/static/js/script.js
@@ -142,10 +142,21 @@ function buildPrompt() {
     negativeID,
     latentID
   );
+  
+  // if vae_name is set to "default", use vae provided by checkpoint loader
+  // if vae_name contains vae checkpoint name, load it and use in nodeVAEDecode 
+  let vaeProviderId = 1;
+  let vaeProviderOutputIdx = 2;
+  if (State.vae_name != "default") {
+    idx += 1;
+    vaeProviderId = idx;
+    vaeProviderOutputIdx = 0;
+    prompt[String(idx)] = nodeVAELoader(State.vae_name);
+  }
 
   idx += 1;
   let vaedecodeID = idx;
-  prompt[String(vaedecodeID)] = nodeVAEDecode(modelID, ksamplerID);
+  prompt[String(vaedecodeID)] = nodeVAEDecode(vaeProviderId, vaeProviderOutputIdx, ksamplerID);
 
   idx += 1;
   let saveimageID = idx;
@@ -280,6 +291,45 @@ function loadCheckpointList() {
       if (checkpoint_list.includes(State.checkpoint_name))
         checkpoint_select.value = State.checkpoint_name;
     }
+  });
+}
+
+function loadVAEList() {
+  requestGET("/object_info/VAELoader", (endpoint, data) => {
+    let vae_list =
+      data.VAELoader.input.required.vae_name[0];
+
+    console.log("selected vae = " + State.vae_name);
+    
+    State.vae_list = vae_list;
+    let vae_dropdown = document.getElementById("vae");
+    let vae_select = document.createElement("select");
+    vae_dropdown.appendChild(vae_select);
+    let option = document.createElement("option");
+    option.disabled = false;
+    option.selected = true;
+    option.innerHTML = "default";
+    option.title = "default";
+    option.value = "default";
+    vae_select.appendChild(option);
+    vae_list.forEach((vae_name) => {
+      option = document.createElement("option");
+      option.title = vae_name;
+      option.value = vae_name;
+      option.innerHTML = vae_name;
+      vae_select.appendChild(option);
+    });
+
+    vae_select.addEventListener("change", (event) => {
+      console.log(vae_select.value);
+      State.vae_name = vae_select.value;
+    });
+
+    if (State.vae_name) {
+      if (vae_list.includes(State.vae_name))
+        vae_select.value = State.vae_name;
+    } 
+
   });
 }
 
@@ -686,6 +736,7 @@ window.addEventListener("load", () => {
   loadCheckpointList();
   loadSamplerList();
   loadLoraList();
+  loadVAEList();
   State.selected_loras.forEach((value, key) => {
     addLora(null, key);
   });

--- a/gligen_gui/templates/base.html
+++ b/gligen_gui/templates/base.html
@@ -100,6 +100,11 @@
               </fieldset>
               <div class="vertical-spacer-1_5"></div>
               <fieldset>
+                <legend>VAE</legend>
+                <div class="dropdown" id="vae"></div>
+              </fieldset>
+              <div class="vertical-spacer-1_5"></div>
+              <fieldset>
                 <legend>sampling</legend>
                 <div class="sampler-params-grid">
                   <label class="grid-label">Steps</label>


### PR DESCRIPTION
If vae selector is set to "default", the vae provided by the CheckpointLoader node will be used. If a custom vae is selected, the VAELoader node will be added to the prompt and used as the source for vae.

Sorry, i'm posting this thing a second time because the old account was probably hidden by anti-spam, it was newly created and had a stupid username, i hope at least this one will not be nuked