### PR TITLE
support none-localhost http URL

### DIFF
--- a/gligen_gui/static/js/draw.js
+++ b/gligen_gui/static/js/draw.js
@@ -102,7 +102,7 @@ function addBox(id, box) {
 
 // Creates and returns a new box and box id
 function newBox(x, y, width, height) {
-  let new_id = crypto.randomUUID();
+  let new_id = "_" + String(Math.floor(Math.random() * 18446744073709551615));
   let new_box = {
     x: x,
     y: y,

--- a/gligen_gui/static/js/script.js
+++ b/gligen_gui/static/js/script.js
@@ -26,9 +26,7 @@ function requestPOST(endpoint, data, handler) {
 }
 
 function getSeed() {
-  let arr = new Uint32Array(2);
-  window.crypto.getRandomValues(arr);
-  return String(BigInt(arr[0]) + (BigInt(arr[1]) << BigInt(32)));
+  return String(Math.floor(Math.random() * 18446744073709551615));
 }
 
 function postInputArgs() {


### PR DESCRIPTION
When running this locally behind a local proxy (0.0.0.0 and exposed as URLs like 192.168.1.144), the ui fails to run because it uses webcrypto to generate random numbers and IDs https://stackoverflow.com/a/46671627

Since these features are only used for generating random numbers and not security related features, there's no reason to limit this to run behind localhost or https URLs. 

With this PR the app runs properly behind all URLs.